### PR TITLE
feat: support multiple db and tables sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Config your database and Databend connection in `config/conf.json`:
   "sourcePass": "123456",
   "sourceDB": "mydb",
   "sourceTable": "my_table",
+  "sourceDbTables": ["mydb.*@table.*"],
   "sourceQuery": "select * from mydb.my_table",
   "sourceWhereCondition": "id < 100",
   "sourceSplitKey": "id",
@@ -52,29 +53,33 @@ INFO[0000] Starting worker
 
 
 ## Parameter References
-| Parameter             | Description              | Default  | example                 | required |
-|-----------------------|--------------------------|----------|-------------------------|----------|
-| sourceHost            | source host              |          |                         | true     |
-| sourcePort            | source port              | 3306     | 3306                    | true     |
-| sourceUser            | source user              |          |                         | true     |
-| sourcePass            | source password          |          |                         | true     |
-| sourceDB              | source database          |          |                         | true     |
-| sourceTable           | source table             |          |                         | true     |
-| sourceQuery           | source query             |          |                         | true     |
-| sourceWhereCondition  | source where condition   |          |                         | false    |
-| sourceSplitKey        | source split key         | no       | "id"                    | false    |
-| sourceSplitTimeKey    | source split time key    | no       | "t1"                    | false    |
-| timeSplitUnit         | time split unit          | "minute" | "day"                   | false    |
-| databendDSN           | databend dsn             | no       | "http://localhost:8000" | true     |
-| databendTable         | databend table           | no       | "db1.tbl"               | true     |
-| batchSize             | batch size               | 1000     | 1000                    | false    |
-| copyPurge             | copy purge               | false    | false                   | false    |
-| copyForce             | copy force               | false    | false                   | false    |
-| DisableVariantCheck   | disable variant check    | false    | false                   | false    |
-| userStage             | user external stage name | ~        | ~                       | false    |
+| Parameter           | Description               | Default  | example                 | required |
+|---------------------|---------------------------|----------|-------------------------|----------|
+| sourceHost          | source host               |          |                         | true     |
+| sourcePort          | source port               | 3306     | 3306                    | true     |
+| sourceUser          | source user               |          |                         | true     |
+| sourcePass          | source password           |          |                         | true     |
+| sourceDB            | source database           |          |                         | true     |
+| sourceTable         | source table              |          |                         | true     |
+| SourceDbTables      | source db tables          | []       | [db.*@table.*,mydb.*.table.*]     | false |
+| sourceQuery         | source query              |          |                         | true     |
+| sourceWhereCondition | source where condition    |          |                         | false    |
+| sourceSplitKey      | source split key          | no       | "id"                    | false    |
+| sourceSplitTimeKey  | source split time key     | no       | "t1"                    | false    |
+| timeSplitUnit       | time split unit           | "minute" | "day"                   | false    |
+| databendDSN         | databend dsn              | no       | "http://localhost:8000" | true     |
+| databendTable       | databend table            | no       | "db1.tbl"               | true     |
+| batchSize           | batch size                | 1000     | 1000                    | false    |
+| copyPurge           | copy purge                | false    | false                   | false    |
+| copyForce           | copy force                | false    | false                   | false    |
+| DisableVariantCheck | disable variant check     | false    | false                   | false    |
+| userStage           | user external stage name  | ~        | ~                       | false    |
 
-NOTE: To reduce the server load, we set the `sourceSplitKey` which is the primary key of the source table. The tool will split the data by the `sourceSplitKey` and sync the data to Databend in parallel.
+NOTE: 1. To reduce the server load, we set the `sourceSplitKey` which is the primary key of the source table. The tool will split the data by the `sourceSplitKey` and sync the data to Databend in parallel.
 The `sourceSplitTimeKey` is used to split the data by the time column. And the `sourceSplitTimeKey` and `sourceSplitKey` must be set at least one.
+2. `sourceDbTables` is used to sync the data from multiple tables. The format is `db.*@table.*` or `db.table.*`. The `.*` is a regex pattern. The `db.*@table.*` means all tables match the regex pattern `table.*` in the database match the regex pattern `db.*`. 
+3. `sourceDbTables` has a higher priority than `sourceTable` and `sourceDB`. If `sourceDbTables` is set, the `sourceTable` will be ignored.
+
 
 ## Two modes
 ### Sync data according to the `sourceSplitKey`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ NOTE: 1. To reduce the server load, we set the `sourceSplitKey` which is the pri
 The `sourceSplitTimeKey` is used to split the data by the time column. And the `sourceSplitTimeKey` and `sourceSplitKey` must be set at least one.
 2. `sourceDbTables` is used to sync the data from multiple tables. The format is `db.*@table.*` or `db.table.*`. The `.*` is a regex pattern. The `db.*@table.*` means all tables match the regex pattern `table.*` in the database match the regex pattern `db.*`. 
 3. `sourceDbTables` has a higher priority than `sourceTable` and `sourceDB`. If `sourceDbTables` is set, the `sourceTable` will be ignored.
+4. The `database` and `table` all support regex pattern. 
 
 
 ## Two modes

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,16 +49,26 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+
+	dbTables := make(map[string][]string)
+	if len(cfg.SourceDbTables) != 0 {
+		dbTables, err = src.GetDbTablesAccordingToSourceDbTables()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		dbs, err := src.GetDatabasesAccordingToSourceDbRegex(cfg.SourceDB)
+		if err != nil {
+			panic(err)
+		}
+		dbTables, err = src.GetTablesAccordingToSourceTableRegex(cfg.SourceTable, dbs)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dbs, err := src.GetDatabasesAccordingToSourceDbRegex()
-	if err != nil {
-		panic(err)
-	}
-	dbTables, err := src.GetTablesAccordingToSourceTableRegex(dbs)
-	if err != nil {
-		panic(err)
-	}
 	for db, tables := range dbTables {
 		for _, table := range tables {
 			w := worker.NewWorker(cfg, db, table, fmt.Sprintf("%s.%s", db, table), ig, src)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,11 +51,23 @@ func main() {
 	}
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	w := worker.NewWorker(cfg, fmt.Sprintf("worker"), ig, src)
-	go func() {
-		w.Run(ctx)
-		wg.Done()
-	}()
+	dbs, err := src.GetDatabasesAccordingToSourceDbRegex()
+	if err != nil {
+		panic(err)
+	}
+	dbTables, err := src.GetTablesAccordingToSourceTableRegex(dbs)
+	if err != nil {
+		panic(err)
+	}
+	for db, tables := range dbTables {
+		for _, table := range tables {
+			w := worker.NewWorker(cfg, db, table, fmt.Sprintf("%s.%s", db, table), ig, src)
+			go func() {
+				w.Run(ctx)
+				wg.Done()
+			}()
+		}
+	}
 	wg.Wait()
 	endTime := fmt.Sprintf("end time: %s", time.Now().Format("2006-01-02 15:04:05"))
 	fmt.Println(endTime)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -48,6 +48,7 @@ func TestMultipleDbTablesWorkflow(t *testing.T) {
 	endTime := fmt.Sprintf("end time: %s", time.Now().Format("2006-01-02 15:04:05"))
 	fmt.Println(endTime)
 	fmt.Println(fmt.Sprintf("total time: %s", time.Since(startTime)))
+	checkTargetTable()
 }
 
 func TestWorkFlow(t *testing.T) {
@@ -144,9 +145,6 @@ CREATE TABLE db2.test_table2 (
 			log.Fatal(err)
 		}
 	}
-
-	checkTargetTable()
-
 }
 
 func prepareMysql() {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -158,7 +158,7 @@ func prepareMysql() {
 
 	// Create table
 	_, err = db.Exec(`
-		CREATE TABLE test_table (
+		CREATE TABLE mydb.test_table (
 			id BIGINT UNSIGNED PRIMARY KEY,
 			int_col INT,
 			varchar_col VARCHAR(255),
@@ -178,7 +178,7 @@ func prepareMysql() {
 	// Insert data
 	for i := 1; i <= 10; i++ {
 		_, err = db.Exec(`
-			INSERT INTO test_table 
+			INSERT INTO mydb.test_table 
 			(id, int_col, varchar_col, float_col, de, bool_col, date_col,  datetime_col, timestamp_col) 
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		`, i, i, fmt.Sprintf("varchar %d", i), float64(i), i%2 == 0, 1.1, "2022-01-01", "2022-01-01 00:00:00", "2024-06-30 20:00:00")
@@ -201,7 +201,7 @@ func prepareMysql() {
 			timeCol = sql.NullTime{Valid: false}
 		}
 		_, err = db.Exec(`
-		INSERT INTO test_table 
+		INSERT INTO mydb.test_table 
 		(id, int_col, varchar_col, float_col, de, bool_col, date_col,  datetime_col, timestamp_col) 
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, i*11, intCol, varcharCol, float64(i), i%2 == 0, 1.1, "2022-01-01", "2022-01-01 00:00:00", timeCol)
@@ -220,7 +220,7 @@ func prepareDatabend() {
 
 	// Create table
 	_, err = db.Exec(`
-		CREATE TABLE test_table (
+		CREATE TABLE if not exists test_table (
 			id UINT64,
 			int_col INT,
 			varchar_col VARCHAR(255),
@@ -246,7 +246,7 @@ func prepareTestConfig() *cfg.Config {
 		SourcePass:           "123456",
 		SourceTable:          "test_table",
 		SourceWhereCondition: "id > 0",
-		SourceQuery:          "select * from default.test_table",
+		SourceQuery:          "select * from mydb.test_table",
 		SourceSplitKey:       "id",
 		SourceSplitTimeKey:   "",
 		DatabendDSN:          "http://databend:databend@localhost:8000",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -32,11 +32,11 @@ func TestWorkFlow(t *testing.T) {
 	}
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	dbs, err := src.GetDatabasesAccordingToSourceDbRegex()
+	dbs, err := src.GetDatabasesAccordingToSourceDbRegex(testConfig.SourceDB)
 	if err != nil {
 		panic(err)
 	}
-	dbTables, err := src.GetTablesAccordingToSourceTableRegex(dbs)
+	dbTables, err := src.GetTablesAccordingToSourceTableRegex(testConfig.SourceTable, dbs)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -32,11 +32,11 @@ func TestMultipleDbTablesWorkflow(t *testing.T) {
 	src, err := source.NewSource(testConfig)
 	assert.NoError(t, err)
 	wg := sync.WaitGroup{}
-	wg.Add(1)
 	dbTables, err := src.GetDbTablesAccordingToSourceDbTables()
 	assert.NoError(t, err)
 	for db, tables := range dbTables {
 		for _, table := range tables {
+			wg.Add(1)
 			w := worker.NewWorker(testConfig, db, table, fmt.Sprintf("%s.%s", db, table), ig, src)
 			go func() {
 				w.Run(context.Background())

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -58,11 +58,13 @@ func TestWorkFlow(t *testing.T) {
 }
 
 func prepareMysql() {
-	db, err := sql.Open("mysql", "root:123456@tcp(127.0.0.1:3306)/default")
+	db, err := sql.Open("mysql", "root:123456@tcp(127.0.0.1:3306)/mysql")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
+	db.Exec("Create database if not exists mydb")
+	db.Exec("Use mydb")
 
 	// Create table
 	_, err = db.Exec(`
@@ -144,7 +146,7 @@ func prepareDatabend() {
 
 func prepareTestConfig() *cfg.Config {
 	config := cfg.Config{
-		SourceDB:             "default",
+		SourceDB:             "mydb",
 		SourceHost:           "127.0.0.1",
 		SourcePort:           3306,
 		SourceUser:           "root",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -45,7 +45,7 @@ func TestMultipleDbTablesWorkflow(t *testing.T) {
 				ig := ingester.NewDatabendIngester(&cfgCopy)
 				src, err := source.NewSource(&cfgCopy)
 				assert.NoError(t, err)
-				w := worker.NewWorkerForTest(&cfgCopy, db, table, fmt.Sprintf("%s.%s", db, table), ig, src)
+				w := worker.NewWorker(&cfgCopy, fmt.Sprintf("%s.%s", db, table), ig, src)
 				w.Run(context.Background())
 				wg.Done()
 			}(testConfig, db, table)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -271,7 +271,7 @@ func prepareMultipleConfig() *cfg.Config {
 		SourcePort:           3306,
 		SourceUser:           "root",
 		SourcePass:           "123456",
-		SourceDbTables:       []string{"db*.test_table*"},
+		SourceDbTables:       []string{"db.*@test_table.*"},
 		SourceTable:          "test_table",
 		SourceWhereCondition: "id > 0",
 		SourceQuery:          "select * from default.test_table",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -140,7 +140,7 @@ CREATE TABLE db2.test_table2 (
 			INSERT INTO db2.test_table2
 			(id, int_col, varchar_col, float_col, de, bool_col, date_col,  datetime_col, timestamp_col) 
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, i, i, fmt.Sprintf("varchar %d", i), float64(i), i%2 == 0, 1.1, "2022-01-01", "2022-01-01 00:00:00", "2024-06-30 20:00:00")
+		`, i+1, i, fmt.Sprintf("varchar %d", i), float64(i), i%2 == 0, 1.1, "2022-01-01", "2022-01-01 00:00:00", "2024-06-30 20:00:00")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	SourcePass           string   `json:"sourcePass"`
 	SourceDB             string   `json:"sourceDB"`
 	SourceTable          string   `json:"sourceTable"`
-	SourceDbTables       []string `json:"SourceDbTables"`       // source db tables format: [db1.table1,db2.table2] or [db1.table*,db*.table*]
+	SourceDbTables       []string `json:"sourceDbTables"`       // source db tables format: [db1.table1,db2.table2] or [db.*@table.*,mydb.*.table.*]
 	SourceQuery          string   `json:"sourceQuery"`          // select * from table where condition
 	SourceWhereCondition string   `json:"sourceWhereCondition"` //example: where id > 100 and id < 200 and time > '2023-01-01'
 	SourceSplitKey       string   `json:"sourceSplitKey"`       // primary split key for split table, only for int type

--- a/config/config.go
+++ b/config/config.go
@@ -35,15 +35,16 @@ var StringToTimeSplitUnit = map[string]TimeSplitUnit{
 
 type Config struct {
 	// Source configuration
-	SourceHost           string `json:"sourceHost"`
-	SourcePort           int    `json:"sourcePort"`
-	SourceUser           string `json:"sourceUser"`
-	SourcePass           string `json:"sourcePass"`
-	SourceDB             string `json:"sourceDB"`
-	SourceTable          string `json:"sourceTable"`
-	SourceQuery          string `json:"sourceQuery"`          // select * from table where condition
-	SourceWhereCondition string `json:"sourceWhereCondition"` //example: where id > 100 and id < 200 and time > '2023-01-01'
-	SourceSplitKey       string `json:"sourceSplitKey"`       // primary split key for split table, only for int type
+	SourceHost           string   `json:"sourceHost"`
+	SourcePort           int      `json:"sourcePort"`
+	SourceUser           string   `json:"sourceUser"`
+	SourcePass           string   `json:"sourcePass"`
+	SourceDB             string   `json:"sourceDB"`
+	SourceTable          string   `json:"sourceTable"`
+	SourceDbTables       []string `json:"SourceDbTables"`       // source db tables format: [db1.table1,db2.table2] or [db1.table*,db*.table*]
+	SourceQuery          string   `json:"sourceQuery"`          // select * from table where condition
+	SourceWhereCondition string   `json:"sourceWhereCondition"` //example: where id > 100 and id < 200 and time > '2023-01-01'
+	SourceSplitKey       string   `json:"sourceSplitKey"`       // primary split key for split table, only for int type
 	// the format of time field must be: 2006-01-02 15:04:05
 	SourceSplitTimeKey string `json:"SourceSplitTimeKey"`           // time field for split table
 	TimeSplitUnit      string `json:"TimeSplitUnit" default:"hour"` // time split unit, default is hour, option is: minute, hour, day

--- a/go.mod
+++ b/go.mod
@@ -3,22 +3,25 @@ module github.com/databendcloud/db-archiver
 go 1.21.0
 
 require (
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/codesuki/go-time-series v0.0.0-20210430055340-c4c8d8fa61d4
 	github.com/datafuselabs/databend-go v0.6.6
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
+	github.com/test-go/testify v1.1.4
 )
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/BurntSushi/toml v1.2.1 // indirect
-	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/ingester/ingest_databend.go
+++ b/ingester/ingest_databend.go
@@ -59,8 +59,8 @@ func (ig *databendIngester) GetAllSyncedCount() (int, error) {
 		return 0, err
 	}
 	defer rows.Close()
+	var count int
 	if rows.Next() {
-		var count int
 		err = rows.Scan(&count)
 		if err != nil {
 			return 0, err

--- a/source/source.go
+++ b/source/source.go
@@ -66,8 +66,8 @@ func (s *Source) GetAllSourceReadRowsCount() (int, error) {
 }
 
 func (s *Source) GetSourceReadRowsCount(table, db string) (int, error) {
-	row := s.db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s", table,
-		db, s.cfg.SourceWhereCondition))
+	row := s.db.QueryRow(fmt.Sprintf("SELECT count(*) FROM %s.%s WHERE %s", db,
+		table, s.cfg.SourceWhereCondition))
 	var rowCount int
 	err := row.Scan(&rowCount)
 	if err != nil {

--- a/source/source.go
+++ b/source/source.go
@@ -25,11 +25,12 @@ type Sourcer interface {
 }
 
 func NewSource(cfg *config.Config) (*Source, error) {
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/default",
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s",
 		cfg.SourceUser,
 		cfg.SourcePass,
 		cfg.SourceHost,
-		cfg.SourcePort))
+		cfg.SourcePort,
+		"default"))
 	if err != nil {
 		return nil, err
 	}

--- a/source/source.go
+++ b/source/source.go
@@ -38,7 +38,7 @@ func NewSource(cfg *config.Config) (*Source, error) {
 		logrus.Errorf("failed to open db: %v", err)
 		return nil, err
 	}
-	fmt.Printf("connected to mysql successfully %v", cfg)
+	//fmt.Printf("connected to mysql successfully %v", cfg)
 	return &Source{
 		db:            db,
 		cfg:           cfg,

--- a/source/source.go
+++ b/source/source.go
@@ -38,6 +38,7 @@ func NewSource(cfg *config.Config) (*Source, error) {
 		logrus.Errorf("failed to open db: %v", err)
 		return nil, err
 	}
+	fmt.Printf("connected to mysql successfully %v", cfg)
 	return &Source{
 		db:            db,
 		cfg:           cfg,

--- a/source/source.go
+++ b/source/source.go
@@ -78,18 +78,6 @@ func (s *Source) GetSourceReadRowsCount(table, db string) (int, error) {
 	return rowCount, nil
 }
 
-func (s *Source) GetRowsCountByConditionSql(conditionSql string) (int, error) {
-	rowCountQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s.%s WHERE %s", s.cfg.SourceDB, s.cfg.SourceTable, conditionSql)
-	row := s.db.QueryRow(rowCountQuery)
-	var rowCount int
-	err := row.Scan(&rowCount)
-	if err != nil {
-		return 0, err
-	}
-
-	return rowCount, nil
-}
-
 func (s *Source) GetMinMaxSplitKey() (int, int, error) {
 	rows, err := s.db.Query(fmt.Sprintf("select min(%s), max(%s) from %s.%s WHERE %s", s.cfg.SourceSplitKey,
 		s.cfg.SourceSplitKey, s.cfg.SourceDB, s.cfg.SourceTable, s.cfg.SourceWhereCondition))
@@ -385,7 +373,6 @@ func (s *Source) GetDatabasesAccordingToSourceDbRegex(sourceDatabasePattern stri
 func (s *Source) GetTablesAccordingToSourceTableRegex(sourceTablePattern string, databases []string) (map[string][]string, error) {
 	dbTables := make(map[string][]string)
 	for _, database := range databases {
-		fmt.Println("database: ", database)
 		rows, err := s.db.Query(fmt.Sprintf("SHOW TABLES FROM %s", database))
 		if err != nil {
 			return nil, err
@@ -423,7 +410,6 @@ func (s *Source) GetDbTablesAccordingToSourceDbTables() (map[string][]string, er
 		if err != nil {
 			return nil, fmt.Errorf("get databases according to sourceDbRegex failed: %v", err)
 		}
-		fmt.Println("dbTable-sjh", dbTable)
 		dbTables, err := s.GetTablesAccordingToSourceTableRegex(dbTable[1], dbs)
 		if err != nil {
 			return nil, fmt.Errorf("get tables according to sourceTableRegex failed: %v", err)

--- a/source/source.go
+++ b/source/source.go
@@ -348,11 +348,13 @@ func (s *Source) GetDatabasesAccordingToSourceDbRegex(sourceDatabasePattern stri
 		if err != nil {
 			return nil, err
 		}
+		fmt.Println("sourcedatabase pattern", sourceDatabasePattern)
 		match, err := regexp.MatchString(sourceDatabasePattern, database)
 		if err != nil {
 			return nil, err
 		}
 		if match {
+			fmt.Println("match db: ", database)
 			databases = append(databases, database)
 		}
 	}

--- a/source/source.go
+++ b/source/source.go
@@ -30,7 +30,7 @@ func NewSource(cfg *config.Config) (*Source, error) {
 		cfg.SourcePass,
 		cfg.SourceHost,
 		cfg.SourcePort,
-		"default"))
+		cfg.SourceDB))
 	if err != nil {
 		return nil, err
 	}

--- a/source/source.go
+++ b/source/source.go
@@ -399,6 +399,7 @@ func (s *Source) GetDbTablesAccordingToSourceDbTables() (map[string][]string, er
 		if err != nil {
 			return nil, fmt.Errorf("get databases according to sourceDbRegex failed: %v", err)
 		}
+		fmt.Println("dbTable-sjh", dbTable)
 		dbTables, err := s.GetTablesAccordingToSourceTableRegex(dbTable[1], dbs)
 		if err != nil {
 			return nil, fmt.Errorf("get tables according to sourceTableRegex failed: %v", err)

--- a/source/source.go
+++ b/source/source.go
@@ -25,12 +25,11 @@ type Sourcer interface {
 }
 
 func NewSource(cfg *config.Config) (*Source, error) {
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s",
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/mysql",
 		cfg.SourceUser,
 		cfg.SourcePass,
 		cfg.SourceHost,
-		cfg.SourcePort,
-		cfg.SourceDB))
+		cfg.SourcePort))
 	if err != nil {
 		logrus.Errorf("failed to open db: %v", err)
 		return nil, err

--- a/source/source.go
+++ b/source/source.go
@@ -32,6 +32,7 @@ func NewSource(cfg *config.Config) (*Source, error) {
 		cfg.SourcePort,
 		cfg.SourceDB))
 	if err != nil {
+		logrus.Errorf("failed to open db: %v", err)
 		return nil, err
 	}
 	return &Source{

--- a/source/source.go
+++ b/source/source.go
@@ -394,7 +394,7 @@ func (s *Source) GetTablesAccordingToSourceTableRegex(sourceTablePattern string,
 func (s *Source) GetDbTablesAccordingToSourceDbTables() (map[string][]string, error) {
 	allDbTables := make(map[string][]string)
 	for _, sourceDbTable := range s.cfg.SourceDbTables {
-		dbTable := strings.Split(sourceDbTable, ".")
+		dbTable := strings.Split(sourceDbTable, "@") // because `.` in regex is a special character, so use `@` to split
 		if len(dbTable) != 2 {
 			return nil, fmt.Errorf("invalid sourceDbTable: %s, should be a.b format", sourceDbTable)
 		}

--- a/source/source.go
+++ b/source/source.go
@@ -362,6 +362,7 @@ func (s *Source) GetDatabasesAccordingToSourceDbRegex(sourceDatabasePattern stri
 func (s *Source) GetTablesAccordingToSourceTableRegex(sourceTablePattern string, databases []string) (map[string][]string, error) {
 	dbTables := make(map[string][]string)
 	for _, database := range databases {
+		fmt.Println("database: ", database)
 		rows, err := s.db.Query(fmt.Sprintf("SHOW TABLES FROM %s", database))
 		if err != nil {
 			return nil, err

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -3,7 +3,10 @@ package source
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"testing"
+
+	"github.com/test-go/testify/assert"
 
 	"github.com/databendcloud/db-archiver/config"
 )
@@ -182,4 +185,19 @@ func TestSplitConditionsByMaxThread(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMatchDatabase(t *testing.T) {
+	databasePattern := "db.*"
+	sourceDbs := []string{"db1", "db2", "default"}
+	targetDbs := []string{"db1", "db2"}
+	res := []string{}
+	for _, sourceDb := range sourceDbs {
+		match, err := regexp.MatchString(databasePattern, sourceDb)
+		assert.NoError(t, err)
+		if match {
+			res = append(res, sourceDb)
+		}
+	}
+	assert.Equal(t, targetDbs, res)
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -41,25 +41,6 @@ func NewWorker(cfg *config.Config, name string, ig ingester.DatabendIngester, sr
 	}
 }
 
-func NewWorkerForTest(cfg *config.Config, dbName string, tableName string, name string, ig ingester.DatabendIngester, src *source.Source) *Worker {
-	stats := NewDatabendWorkerStatsRecorder()
-	cfg.SourceDB = dbName
-	cfg.SourceTable = tableName
-	cfg.SourceQuery = fmt.Sprintf("select * from %s.%s", cfg.SourceDB, cfg.SourceTable)
-	src, err := source.NewSource(cfg)
-	if err != nil {
-		return nil
-	}
-
-	return &Worker{
-		Name:          name,
-		Cfg:           cfg,
-		Ig:            ig,
-		Src:           src,
-		statsRecorder: stats,
-	}
-}
-
 func (w *Worker) stepBatchWithCondition(threadNum int, conditionSql string) error {
 	data, columns, err := w.Src.QueryTableData(threadNum, conditionSql)
 	if err != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -19,7 +19,14 @@ type Worker struct {
 	src  *source.Source
 }
 
-func NewWorker(cfg *config.Config, name string, ig ingester.DatabendIngester, src *source.Source) *Worker {
+func NewWorker(cfg *config.Config, dbName string, tableName string, name string, ig ingester.DatabendIngester, src *source.Source) *Worker {
+	cfg.SourceDB = dbName
+	cfg.SourceTable = tableName
+	cfg.SourceQuery = fmt.Sprintf("select * from %s.%s", cfg.SourceDB, cfg.SourceTable)
+	src, err := source.NewSource(cfg)
+	if err != nil {
+		return nil
+	}
 	return &Worker{
 		name: name,
 		cfg:  cfg,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -16,10 +16,10 @@ import (
 )
 
 type Worker struct {
-	name          string
-	cfg           *config.Config
+	Name          string
+	Cfg           *config.Config
 	ig            ingester.DatabendIngester
-	src           *source.Source
+	Src           *source.Source
 	statsRecorder *DatabendWorkerStatsRecorder
 }
 
@@ -39,16 +39,16 @@ func NewWorker(cfg *config.Config, dbName string, tableName string, name string,
 	}
 
 	return &Worker{
-		name:          name,
-		cfg:           cfg,
+		Name:          name,
+		Cfg:           cfg,
 		ig:            ig,
-		src:           src,
+		Src:           src,
 		statsRecorder: stats,
 	}
 }
 
 func (w *Worker) stepBatchWithCondition(threadNum int, conditionSql string) error {
-	data, columns, err := w.src.QueryTableData(threadNum, conditionSql)
+	data, columns, err := w.Src.QueryTableData(threadNum, conditionSql)
 	if err != nil {
 		return err
 	}
@@ -84,26 +84,26 @@ func calculateBytesSize(batch [][]interface{}) int {
 }
 
 func (w *Worker) IsSplitAccordingMaxGoRoutine(minSplitKey, maxSplitKey, batchSize int) bool {
-	return (maxSplitKey-minSplitKey)/batchSize > w.cfg.MaxThread
+	return (maxSplitKey-minSplitKey)/batchSize > w.Cfg.MaxThread
 }
 
 func (w *Worker) stepBatch() error {
 	wg := &sync.WaitGroup{}
-	minSplitKey, maxSplitKey, err := w.src.GetMinMaxSplitKey()
+	minSplitKey, maxSplitKey, err := w.Src.GetMinMaxSplitKey()
 	if err != nil {
 		return err
 	}
 	fmt.Println("minSplitKey", minSplitKey, "maxSplitKey", maxSplitKey)
 
-	if w.IsSplitAccordingMaxGoRoutine(minSplitKey, maxSplitKey, w.cfg.BatchSize) {
-		fmt.Println("split according maxGoRoutine", w.cfg.MaxThread)
-		slimedRange := w.src.SlimCondition(minSplitKey, maxSplitKey)
+	if w.IsSplitAccordingMaxGoRoutine(minSplitKey, maxSplitKey, w.Cfg.BatchSize) {
+		fmt.Println("split according maxGoRoutine", w.Cfg.MaxThread)
+		slimedRange := w.Src.SlimCondition(minSplitKey, maxSplitKey)
 		fmt.Println("slimedRange", slimedRange)
-		wg.Add(w.cfg.MaxThread)
-		for i := 0; i < w.cfg.MaxThread; i++ {
+		wg.Add(w.Cfg.MaxThread)
+		for i := 0; i < w.Cfg.MaxThread; i++ {
 			go func(idx int) {
 				defer wg.Done()
-				conditions := w.src.SplitConditionAccordingMaxGoRoutine(slimedRange[idx][0], slimedRange[idx][1], maxSplitKey)
+				conditions := w.Src.SplitConditionAccordingMaxGoRoutine(slimedRange[idx][0], slimedRange[idx][1], maxSplitKey)
 				logrus.Infof("conditions in one routine: %v", len(conditions))
 				if err != nil {
 					logrus.Errorf("stepBatchWithCondition failed: %v", err)
@@ -120,7 +120,7 @@ func (w *Worker) stepBatch() error {
 		wg.Wait()
 		return nil
 	}
-	conditions := w.src.SplitCondition(minSplitKey, maxSplitKey)
+	conditions := w.Src.SplitCondition(minSplitKey, maxSplitKey)
 	for _, condition := range conditions {
 		wg.Add(1)
 		go func(condition string) {
@@ -137,24 +137,24 @@ func (w *Worker) stepBatch() error {
 
 func (w *Worker) StepBatchByTimeSplitKey() error {
 	wg := &sync.WaitGroup{}
-	minSplitKey, maxSplitKey, err := w.src.GetMinMaxTimeSplitKey()
+	minSplitKey, maxSplitKey, err := w.Src.GetMinMaxTimeSplitKey()
 	if err != nil {
 		return err
 	}
 	fmt.Println("minSplitKey", minSplitKey, "maxSplitKey", maxSplitKey)
 
-	fmt.Println("split according time split key", w.cfg.MaxThread)
-	allConditions, err := w.src.SplitConditionAccordingToTimeSplitKey(minSplitKey, maxSplitKey)
+	fmt.Println("split according time split key", w.Cfg.MaxThread)
+	allConditions, err := w.Src.SplitConditionAccordingToTimeSplitKey(minSplitKey, maxSplitKey)
 	if err != nil {
 		return err
 	}
 	fmt.Println("allConditions: ", len(allConditions))
 	fmt.Println("all split conditions", allConditions)
-	slimedRange := w.src.SplitTimeConditionsByMaxThread(allConditions, w.cfg.MaxThread)
+	slimedRange := w.Src.SplitTimeConditionsByMaxThread(allConditions, w.Cfg.MaxThread)
 	fmt.Println(len(slimedRange))
 	fmt.Println("slimedRange", slimedRange)
-	wg.Add(w.cfg.MaxThread)
-	for i := 0; i < w.cfg.MaxThread; i++ {
+	wg.Add(w.Cfg.MaxThread)
+	for i := 0; i < w.Cfg.MaxThread; i++ {
 		go func(idx int) {
 			defer wg.Done()
 			conditions := slimedRange[idx]
@@ -164,7 +164,7 @@ func (w *Worker) StepBatchByTimeSplitKey() error {
 			}
 			for _, condition := range conditions {
 				logrus.Infof("condition: %s", condition)
-				err := w.stepBatchWithTimeCondition(condition, w.cfg.BatchSize)
+				err := w.stepBatchWithTimeCondition(condition, w.Cfg.BatchSize)
 				if err != nil {
 					logrus.Errorf("stepBatchWithCondition failed: %v", err)
 				}
@@ -180,7 +180,7 @@ func (w *Worker) stepBatchWithTimeCondition(conditionSql string, batchSize int) 
 	offset := 0
 	for {
 		batchSql := fmt.Sprintf("%s LIMIT %d OFFSET %d", conditionSql, batchSize, offset)
-		data, columns, err := w.src.QueryTableData(1, batchSql)
+		data, columns, err := w.Src.QueryTableData(1, batchSql)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func (w *Worker) IsWorkerCorrect() (int, int, bool) {
 	if err != nil {
 		return 0, 0, false
 	}
-	sourceCount, err := w.src.GetAllSourceReadRowsCount()
+	sourceCount, err := w.Src.GetAllSourceReadRowsCount()
 	if err != nil {
 		return 0, 0, false
 	}
@@ -213,15 +213,15 @@ func (w *Worker) IsWorkerCorrect() (int, int, bool) {
 }
 
 func (w *Worker) Run(ctx context.Context) {
-	logrus.Printf("Worker %s checking before start", w.name)
+	logrus.Printf("Worker %s checking before start", w.Name)
 	syncedCount, err := w.ig.GetAllSyncedCount()
 	if err != nil || syncedCount != 0 {
 		logrus.Errorf("pre-check failed: %v", err)
 		return
 	}
 
-	logrus.Printf("Starting worker %s", w.name)
-	if w.cfg.SourceSplitTimeKey != "" {
+	logrus.Printf("Starting worker %s", w.Name)
+	if w.Cfg.SourceSplitTimeKey != "" {
 		err := w.StepBatchByTimeSplitKey()
 		if err != nil {
 			logrus.Errorf("StepBatchByTimeSplitKey failed: %v", err)
@@ -230,23 +230,6 @@ func (w *Worker) Run(ctx context.Context) {
 		err := w.stepBatch()
 		if err != nil {
 			logrus.Errorf("stepBatch failed: %v", err)
-		}
-	}
-
-	targetCount, sourceCount, workerCorrect := w.IsWorkerCorrect()
-
-	if workerCorrect {
-		logrus.Infof("Worker %s finished and data correct, source data count is %d,"+
-			" target data count is %d", w.name, sourceCount, targetCount)
-	} else {
-		logrus.Errorf("Worker %s finished and data incorrect, source data count is %d,"+
-			" but databend data count is %d", w.name, sourceCount, targetCount)
-	}
-
-	if w.cfg.DeleteAfterSync && workerCorrect {
-		err := w.src.DeleteAfterSync()
-		if err != nil {
-			logrus.Errorf("DeleteAfterSync failed: %v, please do it mannually", err)
 		}
 	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -205,7 +205,7 @@ func (w *Worker) IsWorkerCorrect() (int, int, bool) {
 	if err != nil {
 		return 0, 0, false
 	}
-	sourceCount, err := w.src.GetSourceReadRowsCount()
+	sourceCount, err := w.src.GetAllSourceReadRowsCount()
 	if err != nil {
 		return 0, 0, false
 	}
@@ -233,7 +233,7 @@ func (w *Worker) Run(ctx context.Context) {
 		}
 	}
 
-	sourceCount, targetCount, workerCorrect := w.IsWorkerCorrect()
+	targetCount, sourceCount, workerCorrect := w.IsWorkerCorrect()
 
 	if workerCorrect {
 		logrus.Infof("Worker %s finished and data correct, source data count is %d,"+


### PR DESCRIPTION
Support multiple db and tables data sync. 
Fix https://github.com/databendcloud/db-archiver/issues/1.

### Usage:

Use `  "sourceDbTables": ["mydb.*@table.*"],` in conf.json the dbarchiver will sync all the database begin with `mydb` and all the table begin with `table`, such as `mydb1.table1`, `mydb2.table1`, `mydb2.table2`.