### PR TITLE
fix: remove some release target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        TARGETS: [ linux/amd64, darwin/amd64, windows/amd64, linux/arm64, darwin/arm64 ]
+        TARGETS: [ linux/amd64, darwin/amd64, linux/arm64 ]
     env:
       GO_BUILD_ENV: GO111MODULE=on CGO_ENABLED=0
       DIST_DIRS: find * -type d -exec

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         TARGETS: [ linux/amd64, darwin/amd64, linux/arm64 ]
     env:
-      GO_BUILD_ENV: GO111MODULE=on CGO_ENABLED=0
+      GO_BUILD_ENV: GO111MODULE=on CGO_ENABLED=1
       DIST_DIRS: find * -type d -exec
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Because the oracle db type need c complier in https://github.com/databendcloud/db-archiver/pull/47, and it does not support arm64 https://github.com/godror/godror/issues/155, so we remove the target am64 release.